### PR TITLE
Add additional-initialism option to avoid incorrect swagger file name generating

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
+# IDE directories
+.vscode/
+.idea/
+
 k8s-objects-generator
 swagger.json

--- a/split/project.go
+++ b/split/project.go
@@ -3,7 +3,6 @@ package split
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -125,7 +124,7 @@ func (p *Project) PrepareEasyjsonEnv() error {
 	}
 
 	bootstrapFile := filepath.Join(bootstrapDir, "bottle.go")
-	if err := ioutil.WriteFile(bootstrapFile, []byte(EASYJSON_BOOTSTRAP_FILE_CONTENTS), 0644); err != nil {
+	if err := os.WriteFile(bootstrapFile, []byte(EASYJSON_BOOTSTRAP_FILE_CONTENTS), 0644); err != nil {
 		return fmt.Errorf("Cannot create easyjson bootstrap file: %v", err)
 	}
 
@@ -196,19 +195,28 @@ func (p *Project) InvokeSwaggerModelGenerator(packageName string) error {
 	moduleName := packageNameChunks[len(packageNameChunks)-1]
 	swaggerFileName := filepath.Join(targetDir, moduleName, "swagger.json")
 
+	abbrs := []string{"HPA", "AWS", "CSI", "FS", "FC", "GCE", "GRPC", "ISCSI", "NFS", "OS", "RBD", "SE", "IO", "CIDR"}
+
 	args := []string{
 		"generate",
 		"model",
-		"--template-dir",
-		p.SwaggerTemplatesDir,
-		"--allow-template-override",
-		"-f",
-		swaggerFileName,
-		"-t",
-		targetDir,
-		"-m",
-		moduleName,
 	}
+	for _, abbr := range abbrs {
+		args = append(args, "--additional-initialism="+abbr)
+	}
+
+	args = append(args,
+		[]string{
+			"--template-dir",
+			p.SwaggerTemplatesDir,
+			"--allow-template-override",
+			"-f",
+			swaggerFileName,
+			"-t",
+			targetDir,
+			"-m",
+			moduleName,
+		}...)
 
 	extraEnv := make(map[string]string)
 	extraEnv["GOPATH"] = p.OutputDir


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->

This fix adds static list of the `additional-initialism` parameters to the `swagger` generator invocation command to avoid generate file names like `i_s_c_s_i`, etc.

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
