### PR TITLE
Fix mass-generate.sh for supporting filenames change

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 
 k8s-objects-generator
 swagger.json
+k8s-objects/

--- a/mass-generate.sh
+++ b/mass-generate.sh
@@ -54,9 +54,10 @@ do
   BRANCH=release-1.$KUBEMINOR
 
   cd "$GIT_DIR"
-  if [ $((n=$(git branch | grep -wic "$BRANCH"))) -gt 0 ]; then
+  git fetch origin
+
+  if [ $((n=$(git branch -r | grep -wic "$BRANCH"))) -gt 0 ]; then
     git checkout $BRANCH
-    git fetch
     git rebase origin/$BRANCH $BRANCH
 
     n=$(git tag | grep -wic "v1.$KUBEMINOR")
@@ -66,8 +67,6 @@ do
     git checkout --orphan $BRANCH
     GIT_TAG="v1.$KUBEMINOR.0-kw1"
   fi
-  git reset --hard
-  git clean -fd
   rsync -av --exclude '.git' --delete-after "$OUT_DIR"/src/github.com/kubewarden/k8s-objects/ "$GIT_DIR"
   golangci-lint run ./...
   git add -- *

--- a/mass-generate.sh
+++ b/mass-generate.sh
@@ -69,6 +69,7 @@ do
   git reset --hard
   git clean -fd
   rsync -av --exclude '.git' --delete-after "$OUT_DIR"/src/github.com/kubewarden/k8s-objects/ "$GIT_DIR"
+  golangci-lint run ./...
   git add -- *
   git commit -F "$GIT_COMMIT_MSG_FILE"
   git tag -s -a -m "$GIT_TAG"  $GIT_TAG

--- a/mass-generate.sh
+++ b/mass-generate.sh
@@ -53,7 +53,7 @@ do
 
   BRANCH=release-1.$KUBEMINOR
 
-  cd $GIT_DIR
+  cd "$GIT_DIR"
   if [ $((n=$(git branch | grep -wic "$BRANCH"))) -gt 0 ]; then
     git checkout $BRANCH
     git fetch
@@ -68,7 +68,7 @@ do
   fi
   git reset --hard
   git clean -fd
-  cp -r $OUT_DIR/src/github.com/kubewarden/k8s-objects/* $GIT_DIR
+  rsync -av --exclude '.git' --delete-after "$OUT_DIR"/src/github.com/kubewarden/k8s-objects/ "$GIT_DIR"
   git add -- *
   git commit -F "$GIT_COMMIT_MSG_FILE"
   git tag -s -a -m "$GIT_TAG"  $GIT_TAG

--- a/split/.gitignore.tmpl
+++ b/split/.gitignore.tmpl
@@ -1,0 +1,3 @@
+# IDE directories
+.vscode/
+.idea/

--- a/split/project.go
+++ b/split/project.go
@@ -2,6 +2,7 @@ package split
 
 import (
 	"bytes"
+	_ "embed"
 	"fmt"
 	"log"
 	"os"
@@ -12,6 +13,9 @@ import (
 
 	"github.com/pkg/errors"
 )
+
+//go:embed .gitignore.tmpl
+var gitignore string
 
 type Project struct {
 	OutputDir           string
@@ -67,6 +71,12 @@ func (p *Project) Init(swaggerData []byte, kubernetesVersion, license string) er
 	err = os.WriteFile(licenseFile, []byte(license), 0644)
 	if err != nil {
 		return errors.Wrapf(err, "cannot write LICENSE file %s", licenseFile)
+	}
+
+	gitignoreFile := filepath.Join(p.Root, ".gitignore")
+	err = os.WriteFile(gitignoreFile, []byte(gitignore), 0644)
+	if err != nil {
+		return errors.Wrapf(err, "cannot write .gitignore file %s", licenseFile)
 	}
 
 	return nil


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
This is adoption of the mass-generate.sh to utilize `rsync` instead of the `cp` command to support delete files in target which are not present in source.
Also adds minimal `.gitignore` file to the generated project

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
