### PR TITLE
Add ability to specify Kubernetes versions range in mass-generate.sh

### DIFF
--- a/mass-generate.sh
+++ b/mass-generate.sh
@@ -10,6 +10,10 @@ set -e
 OUT_DIR=~/k8s-data-types
 GIT_DIR=~/checkout/kubernetes/kubewarden/k8s-objects
 
+# Able to define Kubernetes versions range (for testing)
+KUBERNETES_VERSION_MIN="${KUBEMINOR_MIN:-14}"
+KUBERNETES_VERSION_MAX="${KUBEMINOR_MAX:-26}"
+
 while [[ $# -gt 0 ]]; do
   case $1 in
     -m|--message)
@@ -43,10 +47,10 @@ if [ -z "$GIT_COMMIT_MSG_FILE" ]; then
   exit 1
 fi
 
-for KUBEMINOR in {14..26}
+for KUBEMINOR in $(eval "echo {$KUBERNETES_VERSION_MIN..$KUBERNETES_VERSION_MAX}");
 do
   echo ==================================
-  echo PROCESSING KUBERNETES 1.$KUBEMINOR
+  echo PROCESSING KUBERNETES "1.$KUBEMINOR"
   echo ==================================
 
   ./k8s-objects-generator -kube-version "1.$KUBEMINOR" -o "$OUT_DIR"
@@ -54,23 +58,25 @@ do
   BRANCH=release-1.$KUBEMINOR
 
   cd "$GIT_DIR"
-  git fetch origin
+  git checkout main
+  upstream=$(git rev-parse --abbrev-ref --symbolic-full-name '@{u}' | awk -F "/" '{print $1}')
+  git fetch "$upstream"
 
   if [ $((n=$(git branch -r | grep -wic "$BRANCH"))) -gt 0 ]; then
-    git checkout $BRANCH
-    git rebase origin/$BRANCH $BRANCH
+    git checkout "$BRANCH"
+    git rebase "$upstream"/"$BRANCH" "$BRANCH"
 
     n=$(git tag | grep -wic "v1.$KUBEMINOR")
 
     GIT_TAG="v1.$KUBEMINOR.0-kw$((n+1))"
   else
-    git checkout --orphan $BRANCH
+    git checkout --orphan "$BRANCH"
     GIT_TAG="v1.$KUBEMINOR.0-kw1"
   fi
   rsync -av --exclude '.git' --delete-after "$OUT_DIR"/src/github.com/kubewarden/k8s-objects/ "$GIT_DIR"
   golangci-lint run ./...
-  git add -- *
+  git add .
   git commit -F "$GIT_COMMIT_MSG_FILE"
-  git tag -s -a -m "$GIT_TAG"  $GIT_TAG
+  git tag -s -a -m "$GIT_TAG" "$GIT_TAG"
   cd -
 done

--- a/mass-generate.sh
+++ b/mass-generate.sh
@@ -47,6 +47,7 @@ if [ -z "$GIT_COMMIT_MSG_FILE" ]; then
   exit 1
 fi
 
+make build
 for KUBEMINOR in $(eval "echo {$KUBERNETES_VERSION_MIN..$KUBERNETES_VERSION_MAX}");
 do
   echo ==================================


### PR DESCRIPTION
## Description

<!-- Please provide the link to the GitHub issue you are addressing -->
* Able to customize Kubernetes versions range (for quick tests)
* Able to have git `upstream` name different from `origin` 
* `git add .` instead of the  `git add -- *` which missed new `.gitignore` in the root
* `make build` before generate in script to avoid running on old version

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information


### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
