### PR TITLE
Fix golang-set v1 to v2 migration for all files

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,6 @@ go 1.20
 
 require (
 	github.com/blang/semver/v4 v4.0.0
-	github.com/deckarep/golang-set v1.8.0
 	github.com/deckarep/golang-set/v2 v2.3.0
 	github.com/go-openapi/spec v0.20.8
 	github.com/heimdalr/dag v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -52,8 +52,6 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/deckarep/golang-set v1.8.0 h1:sk9/l/KqpunDwP7pSjUg0keiOOLEnOBHzykLrsPppp4=
-github.com/deckarep/golang-set v1.8.0/go.mod h1:5nI87KwE7wgsBU1F4GKAw2Qod7p5kyS383rP6+o6qqo=
 github.com/deckarep/golang-set/v2 v2.3.0 h1:qs18EKUfHm2X9fA50Mr/M5hccg2tNnVqsiBImnyDs0g=
 github.com/deckarep/golang-set/v2 v2.3.0/go.mod h1:VAky9rY/yGXJOLEDv3OMci+7wtDpOF4IN+y82NBOac4=
 github.com/emirpasic/gods v1.18.1 h1:FXtiHYKDGKCW2KzwZKx0iC0PQmdlorYgdFG9jPXJ1Bc=

--- a/split/refactoring_plan.go
+++ b/split/refactoring_plan.go
@@ -69,9 +69,7 @@ func (r *RefactoringPlan) DependenciesGraph() (*dag.DAG, error) {
 			}
 		}
 
-		for depName := range pkg.Dependencies.Iterator().C {
-			name := depName.(string)
-
+		for name := range pkg.Dependencies.Iterator().C {
 			// ensure the dependency is known by the DAG
 			if _, err := dependenciesGraph.GetVertex(name); err != nil {
 				_, found := r.Packages[name]

--- a/swagger_helpers/definition.go
+++ b/swagger_helpers/definition.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"strings"
 
-	mapset "github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set/v2"
 	openapi_spec "github.com/go-openapi/spec"
 	"github.com/pkg/errors"
 )
@@ -25,7 +25,7 @@ type Definition struct {
 	// For example, if a definition has a `meta` property of type
 	// `apimachinery/pkg/apis/meta/v1/ObjectMeta`, then this definition depends
 	// on `apimachinery/pkg/apis/meta/v1/`
-	dependencies mapset.Set
+	dependencies mapset.Set[string]
 }
 
 func NewDefinition(definition openapi_spec.Schema, id string) (*Definition, error) {
@@ -42,7 +42,7 @@ func NewDefinition(definition openapi_spec.Schema, id string) (*Definition, erro
 		SwaggerDefinition: definition,
 		PackageName:       packageName,
 		TypeName:          typeName,
-		dependencies:      mapset.NewSet(),
+		dependencies:      mapset.NewSet[string](),
 	}
 
 	if err := plan.computeDependencies(); err != nil {
@@ -53,7 +53,7 @@ func NewDefinition(definition openapi_spec.Schema, id string) (*Definition, erro
 }
 
 func (d *Definition) computeDependencies() error {
-	propImports := []PropertyImport{}
+	var propImports []PropertyImport
 
 	for name, property := range d.SwaggerDefinition.Properties {
 		propImport, err := NewPropertyImportFromRef(&property.SchemaProps.Ref)
@@ -120,7 +120,7 @@ func (d *Definition) GeneratePatchedOpenAPIDef(gitRepo string, interfaces *Inter
 		return definition, nil
 	}
 
-	required := mapset.NewSet()
+	required := mapset.NewSet[string]()
 	for _, r := range d.SwaggerDefinition.Required {
 		required.Add(r)
 	}

--- a/swagger_helpers/interface_registry.go
+++ b/swagger_helpers/interface_registry.go
@@ -4,18 +4,18 @@ import (
 	"fmt"
 	"strings"
 
-	mapset "github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set/v2"
 )
 
 // Keeps track of all the `interface` objects that are defined inside of the
 // project
 type InterfaceRegistry struct {
-	interfacesByModule map[string]mapset.Set
+	interfacesByModule map[string]mapset.Set[string]
 }
 
 func NewInterfaceRegistry() InterfaceRegistry {
 	return InterfaceRegistry{
-		interfacesByModule: make(map[string]mapset.Set),
+		interfacesByModule: make(map[string]mapset.Set[string]),
 	}
 }
 
@@ -24,7 +24,7 @@ func NewInterfaceRegistry() InterfaceRegistry {
 func (r *InterfaceRegistry) RegisterInterface(module, name string) {
 	interfaces, known := r.interfacesByModule[module]
 	if !known {
-		interfaces = mapset.NewSet()
+		interfaces = mapset.NewSet[string]()
 	}
 	interfaces.Add(name)
 

--- a/swagger_helpers/package.go
+++ b/swagger_helpers/package.go
@@ -1,7 +1,7 @@
 package swagger_helpers
 
 import (
-	mapset "github.com/deckarep/golang-set"
+	mapset "github.com/deckarep/golang-set/v2"
 	openapi_spec "github.com/go-openapi/spec"
 	"github.com/pkg/errors"
 )
@@ -14,14 +14,14 @@ type Package struct {
 	Definitions []*Definition
 
 	// list of package names this one depends on
-	Dependencies mapset.Set
+	Dependencies mapset.Set[string]
 }
 
 func NewPackage(name string) Package {
 	return Package{
 		Name:         name,
 		Definitions:  []*Definition{},
-		Dependencies: mapset.NewSet(),
+		Dependencies: mapset.NewSet[string](),
 	}
 }
 


### PR DESCRIPTION
## Description
This is fix for migration of the `golang-set` from `v1` to '`v2' missed in #18 

<!-- Please provide the link to the GitHub issue you are addressing -->

<!-- Please provide the link to the documentation related to your change, if applicable -->
<!-- [Documentation](https://<insert your url>) -->

## Test

<!-- Please provides a short description about how to test your pullrequest -->
To test this pull request, you can run the following commands:

<!--
```shell
cp <to_package_directory>
go test
```
-->

## Additional Information

### Tradeoff

<!-- Please describe, if any, the tradeoffs that you found acceptable in this pull request -->

### Potential improvement

<!-- Please describe, if any, potential improvement that you are envisioning -->
