### PR TITLE
fix: bump generated go.mod go version

### DIFF
--- a/split/project.go
+++ b/split/project.go
@@ -93,7 +93,7 @@ func (p *Project) SwaggerFile() string {
 const GO_MOD_TEMPLATE = `
 module {{ .Repository }}
 
-go 1.17
+go 1.20
 
 replace github.com/go-openapi/strfmt => github.com/kubewarden/strfmt v0.1.3
 `


### PR DESCRIPTION
## Description

Bumps the generated `go.mod` go version to 1.20.

## Test
-



## Additional Information

-
